### PR TITLE
NanoUtils 0.3.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+0.3.3
+*****
+* Added ``PathType``, an annotation for `path-like <https://docs.python.org/3/glossary.html#term-path-like-object>`_ objects.
+* Added the ``copy`` argument to ``as_nd_array()``.
+
+
 0.3.2
 *****
 * Fixed a bug with ``split_dict()``.

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@
 
 
 ################
-Nano-Utils 0.3.2
+Nano-Utils 0.3.3
 ################
 Utility functions used throughout the various nlesc-nano repositories.
 

--- a/nanoutils/__version__.py
+++ b/nanoutils/__version__.py
@@ -1,3 +1,3 @@
 """The **Nano-Utils** version."""
 
-__version__ = '0.3.2'
+__version__ = '0.3.3'

--- a/nanoutils/numpy_utils.py
+++ b/nanoutils/numpy_utils.py
@@ -52,7 +52,8 @@ __all__ = ['as_nd_array', 'array_combinations', 'fill_diagonal_blocks']
 
 
 @raise_if(NUMPY_EX)
-def as_nd_array(value: Union[Iterable, ArrayLike], dtype: DtypeLike, ndmin: int = 1) -> ndarray:
+def as_nd_array(value: Union[Iterable, ArrayLike], dtype: DtypeLike,
+                ndmin: int = 1, copy: bool = False) -> ndarray:
     """Construct a numpy array from an iterable or array-like object.
 
     Examples
@@ -80,6 +81,8 @@ def as_nd_array(value: Union[Iterable, ArrayLike], dtype: DtypeLike, ndmin: int 
         The data type of the to-be returned array.
     ndmin : :class:`int`
         The minimum dimensionality of the to-be returned array.
+    copy : :class:`bool`
+        If :data:`True`, always return a copy.
 
     Returns
     -------
@@ -88,7 +91,7 @@ def as_nd_array(value: Union[Iterable, ArrayLike], dtype: DtypeLike, ndmin: int 
 
     """
     try:
-        return np.array(value, dtype=dtype, ndmin=ndmin, copy=False)
+        return np.array(value, dtype=dtype, ndmin=ndmin, copy=copy)
 
     except TypeError as ex:
         if not isinstance(value, abc.Iterable):

--- a/nanoutils/typing_utils.py
+++ b/nanoutils/typing_utils.py
@@ -12,10 +12,20 @@ Index
 :class:`~typing.SupportsIndex`      An ABC with one abstract method :meth:`~SupportsIndex.__index__`.
 :class:`~typing.TypedDict`          A simple typed name space. At runtime it is equivalent to a plain :class:`dict`.
 :func:`~typing.runtime_checkable`   Mark a protocol class as a runtime protocol, so that it an be used with :func:`isinstance()` and :func:`issubclass()`.
+:data:`~nanoutils.PathType`         An annotation for `path-like <https://docs.python.org/3/glossary.html#term-path-like-object>`_ objects.
 =================================== ======================================================================================================================================
+
+API
+---
+.. currentmodule:: nanoutils
+.. data:: PathType
+    :value: typing.Union[str, bytes, os.PathLike]
+
+    An annotation for `path-like <https://docs.python.org/3/glossary.html#term-path-like-object>`_ objects.
 
 """  # noqa: E501
 
+import os
 import sys
 from abc import abstractmethod
 from typing import Union, Iterable
@@ -38,5 +48,8 @@ else:
     from typing import Literal, Final, final, Protocol, TypedDict, SupportsIndex, runtime_checkable
 
 __all__ = [
-    'Literal', 'Final', 'final', 'Protocol', 'SupportsIndex', 'TypedDict', 'runtime_checkable'
+    'Literal', 'Final', 'final', 'Protocol', 'SupportsIndex', 'TypedDict', 'runtime_checkable',
+    'PathType'
 ]
+
+PathType = Union[str, bytes, os.PathLike]


### PR DESCRIPTION
* Added ``PathType``, an annotation for [path-like](https://docs.python.org/3/glossary.html#term-path-like-object) objects.
* Added the ``copy`` argument to ``as_nd_array()``.