### PR TITLE
Nano-Utils 0.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 0.4.0
 *****
-* Added the `AbstractFileContainer` class and `file_to_context()` function.
+* Added the ``AbstractFileContainer`` class and ``file_to_context()`` function.
 * Marked all internally used type annotations are private.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,12 +18,6 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 * Added the ``copy`` argument to ``as_nd_array()``.
 
 
-0.3.3
-*****
-* Added ``PathType``, an annotation for `path-like <https://docs.python.org/3/glossary.html#term-path-like-object>`_ objects.
-* Added the ``copy`` argument to ``as_nd_array()``.
-
-
 0.3.2
 *****
 * Fixed a bug with ``split_dict()``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 *****
 * Added the ``AbstractFileContainer`` class and ``file_to_context()`` function.
 * Marked all internally used type annotations are private.
+* Added `contextlib2 <https://github.com/jazzband/contextlib2>`_ as a dependency for Python 3.6.
 
 
 0.3.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
+0.4.0
+*****
+* Added the `AbstractFileContainer` class and `file_to_context()` function.
+* Marked all internally used type annotations are private.
+
 
 0.3.3
 *****

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
+
 0.4.0
 *****
 * Added the ``AbstractFileContainer`` class and ``file_to_context()`` function.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,12 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 * Added the ``copy`` argument to ``as_nd_array()``.
 
 
+0.3.3
+*****
+* Added ``PathType``, an annotation for `path-like <https://docs.python.org/3/glossary.html#term-path-like-object>`_ objects.
+* Added the ``copy`` argument to ``as_nd_array()``.
+
+
 0.3.2
 *****
 * Fixed a bug with ``split_dict()``.

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@
 
 
 ################
-Nano-Utils 0.3.3
+Nano-Utils 0.4.0
 ################
 Utility functions used throughout the various nlesc-nano repositories.
 

--- a/docs/0_documentation.rst
+++ b/docs/0_documentation.rst
@@ -7,3 +7,4 @@ API
     4_typing.rst
     5_numpy.rst
     6_set_attr.rst
+    7_file_container.rst

--- a/docs/7_file_container.rst
+++ b/docs/7_file_container.rst
@@ -1,0 +1,3 @@
+nanoutils.file_container
+========================
+.. automodule:: nanoutils.file_container

--- a/nanoutils/__init__.py
+++ b/nanoutils/__init__.py
@@ -4,12 +4,13 @@
 
 from .__version__ import __version__
 
-from . import typing_utils, empty, utils, numpy_utils, schema, set_attr
+from . import typing_utils, empty, utils, numpy_utils, schema, set_attr, file_container
 from .typing_utils import *
 from .empty import *
 from .utils import *
 from .numpy_utils import *
 from .set_attr import *
+from .file_container import *
 from .schema import (
     Default, Formatter, supports_float, supports_int,
     isinstance_factory, issubclass_factory, import_factory
@@ -26,3 +27,4 @@ __all__ += utils.__all__
 __all__ += numpy_utils.__all__
 __all__ += schema.__all__
 __all__ += set_attr.__all__
+__all__ += file_container.__all__

--- a/nanoutils/__version__.py
+++ b/nanoutils/__version__.py
@@ -1,3 +1,3 @@
 """The **Nano-Utils** version."""
 
-__version__ = '0.3.3'
+__version__ = '0.4.0'

--- a/nanoutils/file_container.py
+++ b/nanoutils/file_container.py
@@ -1,0 +1,267 @@
+"""An abstract container for reading and writing files.
+
+Index
+-----
+.. currentmodule:: FOX.io.file_container
+.. autosummary::
+    AbstractFileContainer
+
+API
+---
+.. autoclass:: AbstractFileContainer
+    :members:
+    :private-members:
+    :special-members:
+
+"""
+
+import sys
+import os
+import io
+from functools import partial
+from abc import ABCMeta, abstractmethod
+from codecs import iterdecode, encode
+from typing import (
+    Dict, Optional, Any, Iterable, Iterator, Union, AnyStr, Callable, ContextManager,
+    TypeVar, AnyStr, overload, IO, Type
+)
+
+from .typing_utils import PathType, OpenTextMode, OpenBinaryMode, final
+
+if sys.version_info < (3, 7):
+    from contextlib2 import nullcontext
+else:
+    from contextlib import nullcontext
+
+__all__ = ['AbstractFileContainer']
+
+T = TypeVar('T')
+ST = TypeVar('ST', bound='AbstractFileContainer')
+CT = TypeVar('CT', bound=Callable)
+
+a = file_to_context('bob')
+b = file_to_context('bob', mode='r')
+c = file_to_context('bob', mode='rb')
+
+
+@overload
+def file_to_context(file: IO[AnyStr], **kwargs: Any) -> ContextManager[IO[AnyStr]]: ...
+@overload
+def file_to_context(file: Union[int, PathType], mode: OpenTextMode = ..., **kwargs: Any) -> ContextManager[IO[str]]: ...  # type: ignore
+@overload
+def file_to_context(file: Union[int, PathType], mode: OpenBinaryMode = ..., **kwargs: Any) -> ContextManager[IO[bytes]]: ...
+def file_to_context(file, mode='r', **kwargs):
+    r"""Take a path- or file-like object and return an appropiate context manager instance.
+
+    Passing a path-like object will supply it to :func:`open`,
+    while passing a file-like object will pass it to :class:`contextlib.nullcontext`.
+
+    Examples
+    --------
+    .. code:: python
+
+        >>> from io import StringIO
+        >>> from nanoutils import file_to_context
+
+        >>> path_like = 'file_name.txt'
+        >>> file_like = StringIO('this is a file-like object')
+
+        >>> context1 = file_to_context(path_like)
+        >>> context2 = file_to_context(file_like)
+
+        >>> with context1 as f1, with context2 as f2:
+        ...     ... # insert operations here
+
+    Parameters
+    ----------
+    file : :class:`str`, :class:`bytes`, :class:`os.PathLike` or :class:`io.IOBase`
+        A `path- <https://docs.python.org/3/glossary.html#term-path-like-object>`_ or
+        `file-like <https://docs.python.org/3/glossary.html#term-file-object>`_ object.
+    /**kwargs : :data:`~typing.Any`
+        Further keyword arguments for :func:`open`.
+        Only relevant if **file** is a path-like object.
+
+    Returns
+    -------
+    :func:`open` or :class:`~contextlib.nullcontext`
+        An initialized context manager.
+        Entering the context manager will return a file-like object.
+
+    """
+    # path-like object
+    try:
+        return open(file, **kwargs)
+
+    # a file-like object (hopefully)
+    except TypeError:
+        return nullcontext(file)
+
+
+def _null_func(obj: T) -> T:
+    """Return the passed object."""
+    return obj
+
+
+class AbstractFileContainer(metaclass=ABCMeta):
+    """An abstract container for reading and writing files.
+
+    Two public methods are defined within this class:
+
+    * :meth:`AbstractFileContainer.read`: Construct a new instance from this object's class by
+        reading the content to a file or file object.
+        How the content of the to-be read file is parsed has to be defined in the
+        :meth:`AbstractFileContainer._read_iterate` abstract method.
+    * :meth:`AbstractFileContainer.write`: Write the content of this instance to an opened
+        file or file object.
+        How the content of the to-be exported class instance is parsed has to be defined in
+        the :meth:`AbstractFileContainer._write_iterate`
+
+    The opening, closing and en-/decoding of files is handled by two above-mentioned methods;
+    the parsing
+    * :meth:`AbstractFileContainer._read_iterate`
+    * :meth:`AbstractFileContainer._write_iterate`
+
+    """
+
+    __slots__: Union[str, Iterable[str]] = ()
+
+    @abstractmethod
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize an instance."""
+        raise NotImplementedError("Trying to call an abstract method")
+
+    @final
+    @classmethod
+    def read(cls: Type[ST], file: Union[PathType, IO],
+             decoding: Optional[str] = None, **kwargs: Any) -> ST:
+        r"""Construct a new instance from this object's class by reading the content of **file**.
+
+        .. _`file object`: https://docs.python.org/3/glossary.html#term-file-object
+
+        Parameters
+        ----------
+        file : :class:`str`, :class:`bytes`, :class:`os.PathLike` or :class:`io.IOBase`
+            A `path- <https://docs.python.org/3/glossary.html#term-path-like-object>`_ or
+            `file-like <https://docs.python.org/3/glossary.html#term-file-object>`_ object.
+        decoding : :class:`str`, optional
+            The type of encoding to use when reading from **file**
+            when it will be/is be opened in :class:`bytes` mode.
+            This value should be left empty otherwise.
+        \**kwargs : :data:`~typing.Any`
+            Further keyword arguments for :func:`open`.
+            Only relevant if **file** is a path-like object.
+
+        See Also
+        --------
+        :meth:`AbstractFileContainer._read`
+            A helper function for :meth:`~AbstractFileContainer.read`.
+
+        :meth:`AbstractFileContainer._read_postprocess`
+            Post processing the class instance created by :meth:`AbstractFileContainer.read`.
+
+        """  # noqa
+        kwargs.setdefault('mode', 'r')
+        context_manager = file_to_context(file, **kwargs)
+
+        with context_manager as f:
+            iterator: Iterator[str] = iter(f) if decoding is None else iterdecode(f, decoding)
+            class_dict = cls._read(iterator)
+
+        ret = cls(**class_dict)
+        ret._read_postprocess()
+        return ret
+
+    @classmethod
+    @abstractmethod
+    def _read(cls, iterator: Iterator[str]) -> Dict[str, Any]:
+        r"""A helper function for :meth:`~AbstractFileContainer.read`.
+
+        Parameters
+        ----------
+        iterator : :class:`Iterator<collections.abc.Iterator>` [:class:`str`]
+            An iterator that returns :class:`str` instances upon iteration.
+
+        Returns
+        -------
+        :class:`dict` [:class:`str`, :data:`~typing.Any`]
+            A dictionary with keyword arguments for a new instance of this objects' class.
+
+        See Also
+        --------
+        :meth:`AbstractFileContainer.read`
+            Construct a new instance from this object's class by reading the content of **file**.
+
+        """  # noqa
+        raise NotImplementedError('Trying to call an abstract method')
+
+    def _read_postprocess(self) -> None:
+        r"""Post processing the class instance created by :meth:`.read`.
+
+        See Also
+        --------
+        :meth:`AbstractFileContainer.read`
+            The main method for reading files.
+
+        """
+        pass
+
+    @final
+    def write(self, file: Union[PathType, IO],
+              decoding: Optional[str] = None, **kwargs: Any) -> None:
+        r"""Write the content of this instance to **file**.
+
+        Parameters
+        ----------
+        file : :class:`str`, :class:`bytes`, :class:`os.PathLike` or :class:`io.IOBase`
+            A `path- <https://docs.python.org/3/glossary.html#term-path-like-object>`_ or
+            `file-like <https://docs.python.org/3/glossary.html#term-file-object>`_ object.
+        decoding : :class:`str`, optional
+            The type of encoding to use when writing to **file**
+            when it will be/is be opened in :class:`bytes` mode.
+            This value should be left empty otherwise.
+        \**kwargs : :data:`~typing.Any`
+            Further keyword arguments for :func:`open`.
+            Only relevant if **file** is a path-like object.
+
+        See Also
+        --------
+        :meth:`AbstractFileContainer._write`
+            A helper function for :meth:`~AbstractFileContainer.write`.
+
+        """
+        kwargs.setdefault('mode', 'w')
+        context_manager = file_to_context(file, **kwargs)
+
+        with context_manager as f:
+            encoder = _null_func if decoding is None else partial(encode, encoding=decoding)
+            self._write(f, encoder)  # type: ignore
+
+    @abstractmethod
+    def _write(self, file_obj: IO[AnyStr], encoder: Callable[[str], AnyStr]) -> None:
+        r"""A helper function for :meth:`~AbstractFileContainer.write`.
+
+        Example
+        -------
+        .. code:: python
+
+            >>> iterator = self.as_dict().items()
+            >>> for key, value in iterator:
+            ...     value: str = f'{key} = {value}'
+            ...     write(value)
+            >>> return None
+
+        Parameters
+        ----------
+        file_obj : :class:`IO[AnyStr]<typing.IO>`
+            The opened file.
+        encoder : :class:`Callable[[bytes], AnyStr]<typing.Callable>`
+            A function for converting strings into either :class:`str` or :class:`bytes`,
+            the exact type matching that of **file_obj**.
+
+        See Also
+        --------
+        :meth:`AbstractFileContainer.write`:
+            Write the content of this instance to **file**.
+
+        """
+        raise NotImplementedError('Trying to call an abstract method')

--- a/nanoutils/schema.py
+++ b/nanoutils/schema.py
@@ -34,7 +34,7 @@ from .utils import PartialPrepend, get_importable, construct_api_doc
 __all__ = ['Default', 'Formatter', 'supports_float', 'supports_int',
            'isinstance_factory', 'issubclass_factory', 'import_factory']
 
-T = TypeVar('T')
+_T = TypeVar('_T')
 
 
 @overload
@@ -131,7 +131,7 @@ def supports_int(value: object) -> bool:  # noqa: E302
         return False
 
 
-class Default(Generic[T]):
+class Default(Generic[_T]):
     """A validation class akin to the likes of :class:`schemas.Use`.
 
     Upon executing :meth:`Default.validate` returns the stored :attr:`~Default.value`.
@@ -170,10 +170,10 @@ class Default(Generic[T]):
 
     """
 
-    value: T
+    value: _T
     call: bool
 
-    def __init__(self, value: T, call: bool = True) -> None:
+    def __init__(self, value: _T, call: bool = True) -> None:
         """Initialize an instance."""
         self.value = value
         self.call = call
@@ -182,7 +182,7 @@ class Default(Generic[T]):
         """Implement :code:`str(self)` and :code:`repr(self)`."""
         return f'{self.__class__.__name__}({self.value!r}, call={self.call!r})'
 
-    def validate(self, data: object) -> T:
+    def validate(self, data: object) -> _T:
         """Validate the passed **data**."""
         if self.call and callable(self.value):
             return self.value()
@@ -235,13 +235,13 @@ class Formatter(str):
         return self.format
 
 
-ClassOrTuple = Union[type, Tuple[type, ...]]
+_ClassOrTuple = Union[type, Tuple[type, ...]]
 
-PO = inspect.Parameter.POSITIONAL_ONLY
-POK = inspect.Parameter.POSITIONAL_OR_KEYWORD
+_PO = inspect.Parameter.POSITIONAL_ONLY
+_POK = inspect.Parameter.POSITIONAL_OR_KEYWORD
 
 
-def isinstance_factory(class_or_tuple: ClassOrTuple) -> Callable[[object], bool]:
+def isinstance_factory(class_or_tuple: _ClassOrTuple) -> Callable[[object], bool]:
     """Return a function which checks if the passed object is an instance of **class_or_tuple**.
 
     Examples
@@ -291,13 +291,13 @@ def isinstance_factory(class_or_tuple: ClassOrTuple) -> Callable[[object], bool]
     ret.__module__ = __name__
     ret.__doc__ = f'Return :code:`isinstance(obj, {cls_str})`.'
     ret.__signature__ = inspect.Signature(  # type: ignore
-        parameters=[inspect.Parameter('obj', PO, annotation=object)],
+        parameters=[inspect.Parameter('obj', _PO, annotation=object)],
         return_annotation=bool
     )
     return ret
 
 
-def issubclass_factory(class_or_tuple: ClassOrTuple) -> Callable[[type], bool]:
+def issubclass_factory(class_or_tuple: _ClassOrTuple) -> Callable[[type], bool]:
     """Return a function which checks if the passed class is a subclass of **class_or_tuple**.
 
     Examples
@@ -347,13 +347,13 @@ def issubclass_factory(class_or_tuple: ClassOrTuple) -> Callable[[type], bool]:
     ret.__module__ = __name__
     ret.__doc__ = f'Return :code:`isinstance(obj, {cls_str})`.'
     ret.__signature__ = inspect.Signature(  # type: ignore
-        parameters=[inspect.Parameter('cls', PO, annotation=type)],
+        parameters=[inspect.Parameter('cls', _PO, annotation=type)],
         return_annotation=bool
     )
     return ret
 
 
-def import_factory(validate: Callable[[T], bool]) -> Callable[[str], T]:
+def import_factory(validate: Callable[[_T], bool]) -> Callable[[str], _T]:
     """Return a function which calls :func:`nanoutils.get_importable` with the **validate** argument.
 
     Examples
@@ -403,7 +403,7 @@ def import_factory(validate: Callable[[T], bool]) -> Callable[[str], T]:
     ret.__module__ = __name__
     ret.__doc__ = f'Return :code:`nanoutils.get_importable(string, validate={val_name})`.'
     ret.__signature__ = inspect.Signature(  # type: ignore
-        parameters=[inspect.Parameter('string', POK, annotation=str)],
+        parameters=[inspect.Parameter('string', _POK, annotation=str)],
         return_annotation=object
     )
     return ret

--- a/nanoutils/set_attr.py
+++ b/nanoutils/set_attr.py
@@ -21,12 +21,12 @@ from .utils import construct_api_doc
 
 __all__ = ['SetAttr']
 
-T1 = TypeVar('T1')
-T2 = TypeVar('T2')
-ST = TypeVar('ST', bound='SetAttr')
+_T1 = TypeVar('_T1')
+_T2 = TypeVar('_T2')
+_ST = TypeVar('_ST', bound='SetAttr')
 
 
-class SetAttr(Generic[T1, T2]):
+class SetAttr(Generic[_T1, _T2]):
     """A context manager for temporarily changing an attribute's value.
 
     The :class:`SetAttr` context manager is thread-safe, reusable and reentrant.
@@ -58,8 +58,8 @@ class SetAttr(Generic[T1, T2]):
     __slots__ = ('__weakref__', '_obj', '_name', '_value', '_value_old', '_lock', '_hash')
 
     @property
-    def obj(self) -> T1:
-        """:class:`T1<typing.TypeVar>`: The to-be modified object."""
+    def obj(self) -> _T1:
+        """:class:`object`: The to-be modified object."""
         return self._obj
 
     @property
@@ -68,21 +68,21 @@ class SetAttr(Generic[T1, T2]):
         return self._name
 
     @property
-    def value(self) -> T2:
-        """:class:`T2<typing.TypeVar>`: The value to-be assigned to the :attr:`name` attribute of :attr:`SetAttr.obj`."""  # noqa: E501
+    def value(self) -> _T2:
+        """:class:`object`: The value to-be assigned to the :attr:`name` attribute of :attr:`SetAttr.obj`."""  # noqa: E501
         return self._value
 
     @property
-    def attr(self) -> T2:
-        """:class:`T2<typing.TypeVar>`: Get or set the :attr:`~SetAttr.name` attribute of :attr:`SetAttr.obj`."""  # noqa: E501
+    def attr(self) -> _T2:
+        """:class:`object`: Get or set the :attr:`~SetAttr.name` attribute of :attr:`SetAttr.obj`."""  # noqa: E501
         return getattr(self.obj, self.name)
 
     @attr.setter
-    def attr(self, value: T2) -> None:
+    def attr(self, value: _T2) -> None:
         with self._lock:
             setattr(self.obj, self.name, value)
 
-    def __init__(self, obj: T1, name: str, value: T2) -> None:
+    def __init__(self, obj: _T1, name: str, value: _T2) -> None:
         """Initialize the :class:`SetAttr` context manager.
 
         Parameters
@@ -128,11 +128,11 @@ class SetAttr(Generic[T1, T2]):
         """
         raise TypeError(f"can't pickle {self.__class__.__name__} objects")
 
-    def __copy__(self: ST) -> ST:
+    def __copy__(self: _ST) -> _ST:
         """Implement :func:`copy.copy(self)<copy.copy>`."""
         return self
 
-    def __deepcopy__(self: ST, memo: Optional[Dict[int, Any]] = None) -> ST:
+    def __deepcopy__(self: _ST, memo: Optional[Dict[int, Any]] = None) -> _ST:
         """Implement :func:`copy.deepcopy(self, memo=memo)<copy.deepcopy>`."""
         return self
 

--- a/nanoutils/typing_utils.py
+++ b/nanoutils/typing_utils.py
@@ -66,22 +66,3 @@ __all__ = [
 
 PathType = Union[str, bytes, os.PathLike]
 
-OpenTextMode = Literal[
-    'r', 'r+', '+r', 'rt', 'tr', 'rt+', 'r+t', '+rt', 'tr+', 't+r', '+tr',
-    'w', 'w+', '+w', 'wt', 'tw', 'wt+', 'w+t', '+wt', 'tw+', 't+w', '+tw',
-    'a', 'a+', '+a', 'at', 'ta', 'at+', 'a+t', '+at', 'ta+', 't+a', '+ta',
-    'x', 'x+', '+x', 'xt', 'tx', 'xt+', 'x+t', '+xt', 'tx+', 't+x', '+tx',
-    'U', 'rU', 'Ur', 'rtU', 'rUt', 'Urt', 'trU', 'tUr', 'Utr',
-]
-
-OpenBinaryMode = Literal[
-    'rb+', 'r+b', '+rb', 'br+', 'b+r', '+br',
-    'wb+', 'w+b', '+wb', 'bw+', 'b+w', '+bw',
-    'ab+', 'a+b', '+ab', 'ba+', 'b+a', '+ba',
-    'xb+', 'x+b', '+xb', 'bx+', 'b+x', '+bx',
-    'wb', 'bw',
-    'ab', 'ba',
-    'xb', 'bx',
-    'rb', 'br',
-    'rbU', 'rUb', 'Urb', 'brU', 'bUr', 'Ubr',
-]

--- a/nanoutils/typing_utils.py
+++ b/nanoutils/typing_utils.py
@@ -23,6 +23,18 @@ API
 
     An annotation for `path-like <https://docs.python.org/3/glossary.html#term-path-like-object>`_ objects.
 
+.. data:: OpenTextMode
+    :value: typing.Literal['r', 'r+', '+r', 'rt', 'tr', 'rt+', ...]
+
+    A Literal with accepted values for opening path-like objects in :class:`str` mode.
+    See https://github.com/python/typeshed/blob/master/stdlib/3/io.pyi.
+
+.. data:: OpenBinaryMode
+    :value: typing.Literal['rb+', 'r+b', '+rb', 'br+', 'b+r', '+br', ...]
+
+    A Literal with accepted values for opening path-like objects in :class:`bytes` mode.
+    See https://github.com/python/typeshed/blob/master/stdlib/3/io.pyi.
+
 """  # noqa: E501
 
 import os
@@ -49,7 +61,27 @@ else:
 
 __all__ = [
     'Literal', 'Final', 'final', 'Protocol', 'SupportsIndex', 'TypedDict', 'runtime_checkable',
-    'PathType'
+    'PathType', 'OpenTextMode', 'OpenBinaryMode'
 ]
 
 PathType = Union[str, bytes, os.PathLike]
+
+OpenTextMode = Literal[
+    'r', 'r+', '+r', 'rt', 'tr', 'rt+', 'r+t', '+rt', 'tr+', 't+r', '+tr',
+    'w', 'w+', '+w', 'wt', 'tw', 'wt+', 'w+t', '+wt', 'tw+', 't+w', '+tw',
+    'a', 'a+', '+a', 'at', 'ta', 'at+', 'a+t', '+at', 'ta+', 't+a', '+ta',
+    'x', 'x+', '+x', 'xt', 'tx', 'xt+', 'x+t', '+xt', 'tx+', 't+x', '+tx',
+    'U', 'rU', 'Ur', 'rtU', 'rUt', 'Urt', 'trU', 'tUr', 'Utr',
+]
+
+OpenBinaryMode = Literal[
+    'rb+', 'r+b', '+rb', 'br+', 'b+r', '+br',
+    'wb+', 'w+b', '+wb', 'bw+', 'b+w', '+bw',
+    'ab+', 'a+b', '+ab', 'ba+', 'b+a', '+ba',
+    'xb+', 'x+b', '+xb', 'bx+', 'b+x', '+bx',
+    'wb', 'bw',
+    'ab', 'ba',
+    'xb', 'bx',
+    'rb', 'br',
+    'rbU', 'rUb', 'Urb', 'brU', 'bUr', 'Ubr',
+]

--- a/nanoutils/typing_utils.py
+++ b/nanoutils/typing_utils.py
@@ -61,8 +61,7 @@ else:
 
 __all__ = [
     'Literal', 'Final', 'final', 'Protocol', 'SupportsIndex', 'TypedDict', 'runtime_checkable',
-    'PathType', 'OpenTextMode', 'OpenBinaryMode'
+    'PathType'
 ]
 
 PathType = Union[str, bytes, os.PathLike]
-

--- a/nanoutils/utils.py
+++ b/nanoutils/utils.py
@@ -47,13 +47,13 @@ __all__ = [
     'split_dict'
 ]
 
-T = TypeVar('T')
-KT = TypeVar('KT')
-VT = TypeVar('VT')
-FT = TypeVar('FT', bound=Callable)
+_T = TypeVar('_T')
+_KT = TypeVar('_KT')
+_VT = TypeVar('_VT')
+_FT = TypeVar('_FT', bound=Callable)
 
 
-def group_by_values(iterable: Iterable[Tuple[VT, KT]]) -> Dict[KT, List[VT]]:
+def group_by_values(iterable: Iterable[Tuple[_VT, _KT]]) -> Dict[_KT, List[_VT]]:
     """Take an iterable, yielding 2-tuples, and group all first elements by the second.
 
     Examples
@@ -82,7 +82,7 @@ def group_by_values(iterable: Iterable[Tuple[VT, KT]]) -> Dict[KT, List[VT]]:
 
     """
     ret = {}
-    list_append: Dict[KT, Callable[[VT], None]] = {}
+    list_append: Dict[_KT, Callable[[_VT], None]] = {}
     for value, key in iterable:
         try:
             list_append[key](value)
@@ -92,7 +92,7 @@ def group_by_values(iterable: Iterable[Tuple[VT, KT]]) -> Dict[KT, List[VT]]:
     return ret
 
 
-def set_docstring(docstring: Optional[str]) -> Callable[[FT], FT]:
+def set_docstring(docstring: Optional[str]) -> Callable[[_FT], _FT]:
     """A decorator for assigning docstrings.
 
     Examples
@@ -116,13 +116,13 @@ def set_docstring(docstring: Optional[str]) -> Callable[[FT], FT]:
         The to-be assigned docstring.
 
     """
-    def wrapper(func: FT) -> FT:
+    def wrapper(func: _FT) -> _FT:
         func.__doc__ = docstring
         return func
     return wrapper
 
 
-def get_importable(string: str, validate: Optional[Callable[[T], bool]] = None) -> T:
+def get_importable(string: str, validate: Optional[Callable[[_T], bool]] = None) -> _T:
     """Get an importable object.
 
     Examples
@@ -157,7 +157,7 @@ def get_importable(string: str, validate: Optional[Callable[[T], bool]] = None) 
         raise TypeError("'string' expected a str; observed type: "
                         f"{string.__class__.__name__!r}") from ex
 
-    ret: T = importlib.import_module(head)  # type: ignore
+    ret: _T = importlib.import_module(head)  # type: ignore
     for name in tail:
         ret = getattr(ret, name)
 
@@ -201,14 +201,14 @@ class PartialPrepend(partial):
 
 
 @overload
-def split_dict(dct: MutableMapping[KT, VT], preserve_order: bool = ..., *,
-               keep_keys: Iterable[KT]) -> Dict[KT, VT]:
+def split_dict(dct: MutableMapping[_KT, _VT], preserve_order: bool = ..., *,
+               keep_keys: Iterable[_KT]) -> Dict[_KT, _VT]:
     ...
 @overload  # noqa: E302
-def split_dict(dct: MutableMapping[KT, VT], preserve_order: bool = ..., *,
-               disgard_keys: Iterable[KT]) -> Dict[KT, VT]:
+def split_dict(dct: MutableMapping[_KT, _VT], preserve_order: bool = ..., *,
+               disgard_keys: Iterable[_KT]) -> Dict[_KT, _VT]:
     ...
-def split_dict(dct: MutableMapping[KT, VT], preserve_order: bool = False, *, keep_keys: Iterable[KT] = None, disgard_keys: Iterable[KT] = None) -> Dict[KT, VT]:  # noqa: E302,E501
+def split_dict(dct: MutableMapping[_KT, _VT], preserve_order: bool = False, *, keep_keys: Iterable[_KT] = None, disgard_keys: Iterable[_KT] = None) -> Dict[_KT, _VT]:  # noqa: E302,E501
     r"""Pop all items from **dct** which are in not in **keep_keys** and use them to construct a new dictionary.
 
     Note that, by popping its keys, the passed **dct** will also be modified inplace.
@@ -263,8 +263,8 @@ def split_dict(dct: MutableMapping[KT, VT], preserve_order: bool = False, *, kee
     return {k: dct.pop(k) for k in iterable}
 
 
-def _keep_keys(dct: Mapping[KT, VT], keep_keys: Iterable[KT],
-               preserve_order: bool = False) -> Collection[KT]:
+def _keep_keys(dct: Mapping[_KT, _VT], keep_keys: Iterable[_KT],
+               preserve_order: bool = False) -> Collection[_KT]:
     """A helper function for :func:`split_dict`; used when :code:`keep_keys is not None`."""
     if preserve_order:
         return [k for k in dct if k not in keep_keys]
@@ -275,8 +275,8 @@ def _keep_keys(dct: Mapping[KT, VT], keep_keys: Iterable[KT],
             return set(dct.keys()).difference(keep_keys)
 
 
-def _disgard_keys(dct: Mapping[KT, VT], keep_keys: Iterable[KT],
-                  preserve_order: bool = False) -> Collection[KT]:
+def _disgard_keys(dct: Mapping[_KT, _VT], keep_keys: Iterable[_KT],
+                  preserve_order: bool = False) -> Collection[_KT]:
     """A helper function for :func:`split_dict`; used when :code:`disgard_keys is not None`."""
     if preserve_order:
         return [k for k in dct if k in keep_keys]
@@ -288,7 +288,7 @@ def _disgard_keys(dct: Mapping[KT, VT], keep_keys: Iterable[KT],
 
 
 @overload
-def raise_if(exception: None) -> Callable[[FT], FT]:
+def raise_if(exception: None) -> Callable[[_FT], _FT]:
     ...
 @overload  # noqa: E302
 def raise_if(exception: BaseException) -> Callable[[Callable], Callable[..., NoReturn]]:
@@ -330,11 +330,11 @@ def raise_if(exception: Optional[BaseException]) -> Callable:  # noqa: E302
 
     """
     if exception is None:
-        def decorator(func: FT):
+        def decorator(func: _FT):
             return func
 
     elif isinstance(exception, BaseException):
-        def decorator(func: FT):
+        def decorator(func: _FT):
             @wraps(func)
             def wrapper(*args, **kwargs):
                 raise exception
@@ -483,6 +483,11 @@ def construct_api_doc(glob_dict: Mapping[str, object],
         autosummary='\n'.join(f'    {i}' for i in __all__),
         autofunction='\n'.join(_get_directive(glob_dict[i], i) for i in __all__)
     )
+
+
+def _null_func(obj: _T) -> _T:
+    """Return the passed object."""
+    return obj
 
 
 __doc__ = construct_api_doc(globals(), decorators={'set_docstring', 'raise_if'})

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,8 @@ setup(
     ],
     python_requires='>=3.6',
     install_requires=[
-        'typing_extensions>=3.7.4; python_version<"3.8"'
+        'typing_extensions>=3.7.4; python_version<"3.8"',
+        'contextlib2>=0.6.0; python_version<"3.7"'
     ],
     setup_requires=['pytest-runner'] + docs_require,
     tests_require=tests_require,


### PR DESCRIPTION
* Added the ``AbstractFileContainer`` class and ``file_to_context()`` function.
* Marked all internally used type annotations are private.
* Added [contextlib2](https://github.com/jazzband/contextlib2) as a dependency for Python 3.6.