### PR TITLE
Add aliases for numpy annotations

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,7 +14,7 @@ jobs:
               uses: actions/setup-python@v1
 
             - name: Install dependencies
-              run: pip install twine wheel
+              run: pip install .[build]
 
             - name: Python info
               run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Cancel Previous Runs
-              uses: styfle/cancel-workflow-action
+              uses: styfle/cancel-workflow-action@0.4.0
               with:
                   access_token: ${{ github.token }}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,6 +20,11 @@ jobs:
                 python-version: [3.6, 3.7, 3.8]
 
         steps:
+            - name: Cancel Previous Runs
+              uses: styfle/cancel-workflow-action
+              with:
+                  access_token: ${{ github.token }}
+
             - uses: actions/checkout@v2
 
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+1.1.0
+*****
+* Added alias for the following ``numpy.typing`` annotations:
+  ``ArrayLike``, ``DtypeLike`` & ``ShapeLike``.
+* Fixed an issue with the license in ``MANIFEST.in``.
+* Enable `Cancel Workflow Action <https://github.com/marketplace/actions/cancel-workflow-action>`_ for the unit tests.
+
+
 1.0.1
 *****
 * Validate the passed path-/file-like object in `AbstractFileContainer.read()` and `.write()`.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,10 +8,11 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 1.1.0
 *****
-* Added alias for the following ``numpy.typing`` annotations:
+* Added aliases for the following ``numpy.typing`` annotations:
   ``ArrayLike``, ``DtypeLike`` & ``ShapeLike``.
 * Fixed an issue with the license in ``MANIFEST.in``.
 * Enable `Cancel Workflow Action <https://github.com/marketplace/actions/cancel-workflow-action>`_ for the unit tests.
+* Added tests for building wheels.
 
 
 1.0.1

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@
 
 
 ################
-Nano-Utils 1.0.1
+Nano-Utils 1.1.0
 ################
 Utility functions used throughout the various nlesc-nano repositories.
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,13 @@
 """A pytest ``conftest.py`` file."""
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _pytest.config import Config
 
 
-def pytest_configure(config: Any) -> None:
+def pytest_configure(config: 'Config') -> None:
     """Flake8 is very verbose by default. Silence it.
 
     See Also

--- a/nanoutils/__version__.py
+++ b/nanoutils/__version__.py
@@ -1,3 +1,3 @@
 """The **Nano-Utils** version."""
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'

--- a/nanoutils/numpy_utils.py
+++ b/nanoutils/numpy_utils.py
@@ -34,6 +34,7 @@ from itertools import combinations
 from collections import abc
 
 from .utils import raise_if, construct_api_doc
+from .typing_utils import ArrayLike, DtypeLike
 
 try:
     import numpy as np
@@ -43,10 +44,8 @@ except ImportError as ex:
 
 if TYPE_CHECKING:
     from numpy import ndarray
-    from numpy.typing import DtypeLike, ArrayLike
 else:
-    DtypeLike = 'numpy.dtype'
-    ArrayLike = ndarray = 'numpy.ndarray'
+    ndarray = 'numpy.ndarray'
 
 __all__ = ['as_nd_array', 'array_combinations', 'fill_diagonal_blocks']
 

--- a/nanoutils/typing_utils.py
+++ b/nanoutils/typing_utils.py
@@ -32,16 +32,19 @@ At large scale, the structure of the module is following:
 
 Index
 -----
-=================================== ======================================================================================================================================
-:data:`~typing.Literal`             Special typing form to define literal types (a.k.a. value types).
-:data:`~typing.Final`               Special typing construct to indicate final names to type checkers.
-:func:`~typing.final`               A decorator to indicate final methods and final classes.
-:class:`~typing.Protocol`           Base class for protocol classes.
-:class:`~typing.SupportsIndex`      An ABC with one abstract method :meth:`~object.__index__()`.
-:class:`~typing.TypedDict`          A simple typed name space. At runtime it is equivalent to a plain :class:`dict`.
-:func:`~typing.runtime_checkable`   Mark a protocol class as a runtime protocol, so that it an be used with :func:`isinstance()` and :func:`issubclass()`.
-:data:`~nanoutils.PathType`         An annotation for `path-like <https://docs.python.org/3/glossary.html#term-path-like-object>`_ objects.
-=================================== ======================================================================================================================================
+========================================== ======================================================================================================================================
+:data:`~typing.Literal`                    Special typing form to define literal types (a.k.a. value types).
+:data:`~typing.Final`                      Special typing construct to indicate final names to type checkers.
+:func:`~typing.final`                      A decorator to indicate final methods and final classes.
+:class:`~typing.Protocol`                  Base class for protocol classes.
+:class:`~typing.SupportsIndex`             An ABC with one abstract method :meth:`~object.__index__()`.
+:class:`~typing.TypedDict`                 A simple typed name space. At runtime it is equivalent to a plain :class:`dict`.
+:func:`~typing.runtime_checkable`          Mark a protocol class as a runtime protocol, so that it an be used with :func:`isinstance()` and :func:`issubclass()`.
+:data:`~nanoutils.PathType`                An annotation for `path-like <https://docs.python.org/3/glossary.html#term-path-like-object>`_ objects.
+:data:`~numpy.typing.ArrayLike`            Objects that can be converted to arrays (see :class:`numpy.ndarray`).
+:data:`~numpy.typing.DtypeLike`            Objects that can be converted to dtypes (see :class:`numpy.dtype`).
+:data:`<ShapeLike>numpy.typing._ShapeLike` Objects that can serve as valid array shapes.
+========================================== ======================================================================================================================================
 
 API
 ---
@@ -56,7 +59,7 @@ API
 import os
 import sys
 from abc import abstractmethod
-from typing import Union, Iterable
+from typing import Union, Iterable, Sequence, TYPE_CHECKING
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal, Final, final, Protocol, TypedDict, runtime_checkable
@@ -75,9 +78,21 @@ if sys.version_info < (3, 8):
 else:
     from typing import Literal, Final, final, Protocol, TypedDict, SupportsIndex, runtime_checkable
 
+if TYPE_CHECKING:
+    # Requires numpy >= 1.20
+    from numpy.typing import ArrayLike, DtypeLike, _ShapeLike as ShapeLike
+
+else:
+    ArrayLike = 'numpy.typing.ArrayLike'
+    DtypeLike = 'numpy.typing.DtypeLike'
+    ShapeLike = 'numpy.typing._ShapeLike'
+
 __all__ = [
     'Literal', 'Final', 'final', 'Protocol', 'SupportsIndex', 'TypedDict', 'runtime_checkable',
-    'PathType'
+
+    'PathType',
+
+    'ArrayLike', 'DtypeLike', 'ShapeLike'
 ]
 
 # See https://github.com/python/typeshed/blob/master/stdlib/3/os/path.pyi.

--- a/nanoutils/typing_utils.py
+++ b/nanoutils/typing_utils.py
@@ -59,7 +59,7 @@ API
 import os
 import sys
 from abc import abstractmethod
-from typing import Union, Iterable, Sequence, TYPE_CHECKING
+from typing import Union, Iterable, TYPE_CHECKING
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal, Final, final, Protocol, TypedDict, runtime_checkable

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 description-file = README.rst
-license_files = LICENSE.md
 
 [aliases]
 # Define `python setup.py test`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 description-file = README.rst
+license_files = LICENSE.md
 
 [aliases]
 # Define `python setup.py test`

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,9 @@ tests_require = [
     'pytest-flake8>=1.0.5',
     'pydocstyle>=5.0.0',
     'pytest-pydocstyle>=2.1',
-    'pytest-mypy>=0.6.2'
+    'pytest-mypy>=0.6.2',
+    'twine',
+    'wheel'
 ]
 tests_require += docs_require
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,12 @@ docs_require = [
     'numpy'
 ]
 
+# Requirements for building wheels
+build_requires = [
+    'twine',
+    'wheel'
+]
+
 # Requirements for running tests
 tests_require = [
     'assertionlib',
@@ -33,10 +39,9 @@ tests_require = [
     'pydocstyle>=5.0.0',
     'pytest-pydocstyle>=2.1',
     'pytest-mypy>=0.6.2',
-    'twine',
-    'wheel'
 ]
 tests_require += docs_require
+tests_require += build_requires
 
 setup(
     name='Nano-Utils',
@@ -81,5 +86,9 @@ setup(
     ],
     setup_requires=['pytest-runner'] + docs_require,
     tests_require=tests_require,
-    extras_require={'doc': docs_require, 'test': tests_require}
+    extras_require={
+        'doc': docs_require,
+        'test': tests_require,
+        'build': build_requires
+    }
 )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,11 @@
+"""Test building the Nano-Utils package."""
+
+import subprocess
+
+from nanoutils import delete_finally
+
+
+@delete_finally('dist', 'build')
+def test_build() -> None:
+    """Test if the package is properly build."""
+    subprocess.run('python setup.py sdist bdist_wheel', shell=True, check=True)


### PR DESCRIPTION
* Added alias for the following ``numpy.typing`` annotations: ``ArrayLike``, ``DtypeLike`` & ``ShapeLike``.
* Fixed an issue with the license in ``MANIFEST.in``.
* Enable [Cancel Workflow Action](https://github.com/marketplace/actions/cancel-workflow-action) for the unit tests.
* Added tests for building wheels.