### PR TITLE
Enable tests for Python 3.9

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,7 +39,7 @@ jobs:
               run: pip install cython
 
             - name: Install wheel
-              if: matrix.python-version == 3.9.0-beta.4
+              if: matrix.python-version == '3.9.0-beta.4'
               run: pip install wheel
 
             - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9]
+                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.4]
 
         steps:
             - name: Cancel Previous Runs
@@ -28,7 +28,7 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v2.1.0
               with:
                 python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,12 +32,6 @@ jobs:
               with:
                 python-version: ${{ matrix.python-version }}
 
-            - name: Install Cython
-              # Fix for an issue with installing NumPy on windows with python 3.8
-              # See https://github.com/nlesc-nano/Nano-Utils/pull/18/checks?check_run_id=768354960
-              if: matrix.os == 'windows-latest' && matrix.python-version == 3.8
-              run: pip install cython
-
             - name: Install dependencies
               run: pip install -e .[test]
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, '3.9.0-beta']
+                python-version: [3.6, 3.7, 3.8, '3.9.0-alpha - 3.9.0']
 
         steps:
             - name: Cancel Previous Runs
@@ -39,7 +39,7 @@ jobs:
               run: pip install cython
 
             - name: Install wheel
-              if: matrix.python-version == '3.9.0-beta'
+              if: matrix.python-version == '3.9.0-alpha - 3.9.0'
               run: pip install wheel
 
             - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,7 +30,6 @@ jobs:
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
               uses: actions/setup-python@v2
               with:
-                stable: False
                 python-version: ${{ matrix.python-version }}
 
             - name: Install Cython

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,13 +23,22 @@ jobs:
             - name: Cancel Previous Runs
               uses: styfle/cancel-workflow-action@0.4.1
               with:
-                  access_token: ${{ github.token }}
+                access_token: ${{ github.token }}
 
             - uses: actions/checkout@v2
 
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+              if: matrix.python-version != 3.9
               uses: actions/setup-python@v2
               with:
+                stable: True
+                python-version: ${{ matrix.python-version }}
+
+            - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+              if: matrix.python-version == 3.9
+              uses: actions/setup-python@v2
+              with:
+                stable: False
                 python-version: ${{ matrix.python-version }}
 
             - name: Install Cython

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.4]
+                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.*]
 
         steps:
             - name: Cancel Previous Runs
@@ -28,7 +28,7 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-              uses: actions/setup-python@v2.1.0
+              uses: actions/setup-python@v2.1
               with:
                 python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.4]
+                python-version: [3.6, 3.7, 3.8, 3.9]
 
         steps:
             - name: Cancel Previous Runs

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, '3.9.0-beta.4']
+                python-version: [3.6, 3.7, 3.8, 3.9.0]
 
         steps:
             - name: Cancel Previous Runs

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, '3.9.0-alpha - 3.9.0']
+                python-version: [3.6, 3.7, 3.8, '3.9.0-alpha - 3.9']
 
         steps:
             - name: Cancel Previous Runs
@@ -39,7 +39,7 @@ jobs:
               run: pip install cython
 
             - name: Install wheel
-              if: matrix.python-version == '3.9.0-alpha - 3.9.0'
+              if: matrix.python-version == '3.9.0-alpha - 3.9'
               run: pip install wheel
 
             - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8]
+                python-version: [3.6, 3.7, 3.8, 3.9]
 
         steps:
             - name: Cancel Previous Runs

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.4]
+                python-version: [3.6, 3.7, 3.8, '3.9.0-beta.4']
 
         steps:
             - name: Cancel Previous Runs

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9]
+                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.4]
 
         steps:
             - name: Cancel Previous Runs
@@ -28,18 +28,9 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-              if: matrix.python-version != 3.9
               uses: actions/setup-python@v2
               with:
-                stable: True
                 python-version: ${{ matrix.python-version }}
-
-            - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-              if: matrix.python-version == 3.9
-              uses: actions/setup-python@v2
-              with:
-                stable: False
-                python-version: 3.9.0-beta.4
 
             - name: Install Cython
               # Fix for an issue with installing NumPy on windows with python 3.8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9]
+                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.*]
 
         steps:
             - name: Cancel Previous Runs
@@ -28,18 +28,9 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-              if: matrix.python-version != 3.9
               uses: actions/setup-python@v2
               with:
-                stable: True
                 python-version: ${{ matrix.python-version }}
-
-            - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-              if: matrix.python-version == 3.9
-              uses: actions/setup-python@v2
-              with:
-                stable: False
-                python-version: 3.9.0-beta.4
 
             - name: Install Cython
               # Fix for an issue with installing NumPy on windows with python 3.8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, '3.9.0-beta.4']
+                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.4]
 
         steps:
             - name: Cancel Previous Runs

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9.0]
+                python-version: [3.6, 3.7, 3.8, '3.9.0-beta.4']
 
         steps:
             - name: Cancel Previous Runs

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.*]
+                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.4]
 
         steps:
             - name: Cancel Previous Runs

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,7 +28,7 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-              uses: actions/setup-python@v1
+              uses: actions/setup-python@v2
               with:
                 python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,6 +32,12 @@ jobs:
               with:
                 python-version: ${{ matrix.python-version }}
 
+            - name: Install Cython
+              # Fix for an issue with installing NumPy on windows with python 3.8
+              # See https://github.com/nlesc-nano/Nano-Utils/pull/18/checks?check_run_id=768354960
+              if: matrix.os == 'windows-latest' && matrix.python-version == 3.8
+              run: pip install cython
+
             - name: Install dependencies
               run: pip install -e .[test]
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.*]
+                python-version: [3.6, 3.7, 3.8, 3.9]
 
         steps:
             - name: Cancel Previous Runs
@@ -28,7 +28,7 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v2.1
               with:
                 python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,6 +30,7 @@ jobs:
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
               uses: actions/setup-python@v2
               with:
+                stable: False
                 python-version: ${{ matrix.python-version }}
 
             - name: Install Cython

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9]
+                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.4]
 
         steps:
             - name: Cancel Previous Runs

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,7 +39,7 @@ jobs:
               uses: actions/setup-python@v2
               with:
                 stable: False
-                python-version: ${{ matrix.python-version }}
+                python-version: 3.9.0-beta.4
 
             - name: Install Cython
               # Fix for an issue with installing NumPy on windows with python 3.8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,7 +28,7 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-              uses: actions/setup-python@v2.1
+              uses: actions/setup-python@v2
               with:
                 python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,6 +18,9 @@ jobs:
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
                 python-version: [3.6, 3.7, 3.8, '3.9.0-alpha - 3.9']
+                exclude:
+                    - os: macos-latest
+                      python-version: '3.9.0-alpha - 3.9'
 
         steps:
             - name: Cancel Previous Runs

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.4]
+                python-version: [3.6, 3.7, 3.8, '3.9.0-beta']
 
         steps:
             - name: Cancel Previous Runs
@@ -39,7 +39,7 @@ jobs:
               run: pip install cython
 
             - name: Install wheel
-              if: matrix.python-version == '3.9.0-beta.4'
+              if: matrix.python-version == '3.9.0-beta'
               run: pip install wheel
 
             - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9.0-beta.4]
+                python-version: [3.6, 3.7, 3.8, 3.9]
 
         steps:
             - name: Cancel Previous Runs
@@ -28,9 +28,18 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+              if: matrix.python-version != 3.9
               uses: actions/setup-python@v2
               with:
+                stable: True
                 python-version: ${{ matrix.python-version }}
+
+            - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+              if: matrix.python-version == 3.9
+              uses: actions/setup-python@v2
+              with:
+                stable: False
+                python-version: 3.9.0-beta.4
 
             - name: Install Cython
               # Fix for an issue with installing NumPy on windows with python 3.8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,6 +38,10 @@ jobs:
               if: matrix.os == 'windows-latest' && matrix.python-version == 3.8
               run: pip install cython
 
+            - name: Install wheel
+              if: matrix.python-version == 3.9.0-beta.4
+              run: pip install wheel
+
             - name: Install dependencies
               run: pip install -e .[test]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+1.1.2
+*****
+* Bump the setup-python version to `v2`.
+* Enable tests for Python 3.9.
+
+
 1.1.1
 *****
 * Bump the Cancel Workflow Action version to `0.4.1`.

--- a/README.rst
+++ b/README.rst
@@ -17,10 +17,12 @@
     :target: https://docs.python.org/3.7/
 .. image:: https://img.shields.io/badge/python-3.8-blue.svg
     :target: https://docs.python.org/3.8/
+.. image:: https://img.shields.io/badge/python-3.9-blue.svg
+    :target: https://docs.python.org/3.9/
 
 
 ################
-Nano-Utils 1.1.1
+Nano-Utils 1.1.2
 ################
 Utility functions used throughout the various nlesc-nano repositories.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
-    'sphinx.ext.duration'
+    'sphinx.ext.duration',
+    'sphinx.ext.doctest'
 ]
 
 
@@ -247,6 +248,13 @@ napoleon_use_admonition_for_notes = True
 # Defaults to False.
 napoleon_use_admonition_for_references = True
 
+
+# Python code that is treated like it were put in a testsetup directive for
+# every file that is tested, and for every group.
+# You can use this to e.g. import modules you will always need in your doctests.
+doctest_global_setup = """
+from nanoutils.numpy_utils import NUMPY_EX
+"""
 
 # A string of reStructuredText that will be included at the end of every source file that is read.
 # This is a possible place to add substitutions that

--- a/nanoutils/__version__.py
+++ b/nanoutils/__version__.py
@@ -1,3 +1,3 @@
 """The **Nano-Utils** version."""
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'

--- a/nanoutils/numpy_utils.py
+++ b/nanoutils/numpy_utils.py
@@ -57,7 +57,8 @@ def as_nd_array(array: Union[Iterable, ArrayLike], dtype: DtypeLike,
 
     Examples
     --------
-    .. code:: python
+    .. doctest:: python
+        :skipif: NUMPY_EX is not None
 
         >>> from nanoutils import as_nd_array
 
@@ -107,7 +108,8 @@ def array_combinations(array: ArrayLike, r: int = 2, axis: int = -1) -> ndarray:
 
     Examples
     --------
-    .. code:: python
+    .. doctest:: python
+        :skipif: NUMPY_EX is not None
 
         >>> from nanoutils import array_combinations
 
@@ -182,7 +184,8 @@ def fill_diagonal_blocks(array: ndarray, i: int, j: int, val: float = nan) -> No
 
     Examples
     --------
-    .. code:: python
+    .. doctest:: python
+        :skipif: NUMPY_EX is not None
 
         >>> import numpy as np
         >>> from nanoutils import fill_diagonal_blocks

--- a/nanoutils/numpy_utils.py
+++ b/nanoutils/numpy_utils.py
@@ -38,8 +38,8 @@ from .typing_utils import ArrayLike, DtypeLike
 
 try:
     import numpy as np
-    NUMPY_EX: Optional[ImportError] = None
-except ImportError as ex:
+    NUMPY_EX: Optional[Exception] = None
+except Exception as ex:
     NUMPY_EX = ex
 
 if TYPE_CHECKING:

--- a/numpy_ge_1_20.py
+++ b/numpy_ge_1_20.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-r"""Print :code:`"\nnumpy >= 1.20: TRUE"` if the :mod:`numpy` version is 1.20 or higher; print :code:`"\nnumpy >= 1.20: FALSE"` otherwise.
-
-:code:`"\nnumpy >= 1.20: ERROR"` will be printed if an exception is encountered.
+r"""Print :code:`TRUE` if the :mod:`numpy` version is 1.20 or higher; print :code:`FALSE` otherwise.
 
 Examples
 --------

--- a/numpy_ge_1_20.py
+++ b/numpy_ge_1_20.py
@@ -26,8 +26,8 @@ from nanoutils import VersionInfo
 
 try:
     import numpy as np
-    NUMPY_EX: Optional[ImportError] = None
-except ImportError as ex:
+    NUMPY_EX: Optional[Exception] = None
+except Exception as ex:
     NUMPY_EX = ex
 
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'python-3-6',
         'python-3-7',
         'python-3-8',
+        'python-3-9',
         'libraries'
     ],
     classifiers=[
@@ -76,6 +77,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries',
         'Typing :: Typed'
     ],


### PR DESCRIPTION
* Enable tests for the Python 3.9 Beta.
* Bump the setup-python version to `v2`.
* Version bump: `1.1.1` > `1.1.2`.