### PR TITLE
ENH: Avoid double-loops in `_RecursiveMappingView`

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -8,10 +8,12 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
+              with:
+                  python-version: '3.x'
 
             - name: Install dependencies
               run: pip install wheel twine

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,7 +39,7 @@ jobs:
             -   uses: actions/checkout@v3
 
             -   name: Set up Python ${{ matrix.version }} on ${{ matrix.os }}
-                uses: actions/setup-python@v3
+                uses: actions/setup-python@v4
                 with:
                     python-version: ${{ matrix.version }}
 
@@ -82,10 +82,10 @@ jobs:
         steps:
             -   uses: actions/checkout@v3
 
-            -   name: Set up Python 3.10 on ubuntu-latest
-                uses: actions/setup-python@v3
+            -   name: Set up Python on ubuntu-latest
+                uses: actions/setup-python@v4
                 with:
-                    python-version: "3.10"
+                    python-version: '3.x'
 
             -   name: Install linters
                 run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 2.3.3
 *****
-* *Placeholder*.
+* Avoid double-loops in `_RecursiveMappingView`.
 
 
 2.3.2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include LICENSE.md
-include README.rst
+include nanoutils/py.typed
+include nanoutils/*.pyi

--- a/nanoutils/_lazy_import.py
+++ b/nanoutils/_lazy_import.py
@@ -14,26 +14,15 @@ import types
 import reprlib
 import importlib
 from collections.abc import Mapping, Callable, Iterable
-from typing import Any, TypeVar, Type, Generic, cast, TYPE_CHECKING
+from typing import Any, TypeVar, Type, Generic, TYPE_CHECKING
 
 _T = TypeVar("_T")
 
 if TYPE_CHECKING:
     from typing_extensions import Protocol
-    from typing import (
-        overload,
-        Collection,
-        Union,
-        Tuple,
-        Dict,
-        KeysView,
-        ValuesView,
-        ItemsView,
-        Iterator,
-    )
+    from typing import Union, Tuple, Dict
 
     _KT = TypeVar("_KT")
-    _VT = TypeVar("_VT")
     _VT_co = TypeVar("_VT_co", covariant=True)
     _ST1 = TypeVar("_ST1", bound="LazyImporter[Any]")
     _ST2 = TypeVar("_ST2", bound="MutableLazyImporter[Any]")
@@ -41,26 +30,6 @@ if TYPE_CHECKING:
     class _SupportsKeysAndGetItem(Protocol[_KT, _VT_co]):
         def __getitem__(self, __key: _KT) -> _VT_co: ...
         def keys(self) -> Iterable[_KT]: ...
-
-    # A `Protocol` version of `types.MappingProxyType`
-    class _MappingProtocol(Protocol[_KT, _VT], Collection[_KT]):
-        __hash__: None  # type: ignore
-        def __getitem__(self, k: _KT) -> _VT: ...
-        def __contains__(self, o: object) -> bool: ...
-        @overload
-        def get(self, key: _KT) -> None | _VT: ...
-        @overload
-        def get(self, key: _KT, default: _T) -> _T | _VT: ...
-        def items(self) -> ItemsView[_KT, _VT]: ...
-        def keys(self) -> KeysView[_KT]: ...
-        def values(self) -> ValuesView[_VT]: ...
-        def copy(self) -> dict[_KT, _VT]: ...
-
-        # TODO: Update `__or__` once mypy > 0.910 hits
-        if sys.version_info >= (3, 9):
-            def __reversed__(self) -> Iterator[_KT]: ...
-            def __or__(self, __value: Mapping[_KT, _VT]) -> dict[_KT, _VT]: ...
-            def __ror__(self, __value: Mapping[_KT, _VT]) -> dict[_KT, _VT]: ...
 
     _DictLike = Union[_SupportsKeysAndGetItem[str, str], Iterable[Tuple[str, str]]]
     _ReduceTuple = Tuple[Callable[[str, Dict[str, str]], _T], Tuple[str, Dict[str, str]]]
@@ -114,7 +83,7 @@ class LazyImporter(Generic[_T]):
         return self._module
 
     @property
-    def imports(self) -> _MappingProtocol[str, str]:
+    def imports(self) -> Mapping[str, str]:
         """:class:`types.MappingProxyType[str, str]<types.MappingProxyType>`: Get a mapping that maps object names to their module name."""  # noqa: E501
         return self._imports
 
@@ -127,7 +96,7 @@ class LazyImporter(Generic[_T]):
         if not isinstance(module, types.ModuleType):
             raise TypeError(f"Expected a module, not {type(module).__name__}")
         self._module = module
-        self._imports = cast("_MappingProtocol[str, str]", types.MappingProxyType(dict(imports)))
+        self._imports: Mapping[str, str] = types.MappingProxyType(dict(imports))
 
     @classmethod
     def from_name(cls: Type[_ST1], name: str, imports: _DictLike) -> _ST1:
@@ -158,7 +127,7 @@ class LazyImporter(Generic[_T]):
     def __reduce__(self: _ST1) -> _ReduceTuple[_ST1]:
         """Helper for :mod:`pickle`."""
         cls = type(self)
-        args = (self.module.__name__, self.imports.copy())
+        args = (self.module.__name__, self.imports.copy())  # type: ignore[attr-defined]
         return cls.from_name, args
 
     def __copy__(self: _ST1) -> _ST1:
@@ -179,8 +148,7 @@ class LazyImporter(Generic[_T]):
 
     def __eq__(self, value: object) -> bool:
         """Implement :meth:`self == value<object.__eq__>`."""
-        cls = type(self)
-        if not isinstance(value, cls):
+        if not isinstance(value, LazyImporter):
             return NotImplemented
         return self.module is value.module and self.imports == value.imports
 


### PR DESCRIPTION
They're very slow due to the lazy nature of the class, so instead operate via their `set`-based counterpart.